### PR TITLE
feat#21: user 브랜치 재생성 커밋

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,13 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   testImplementation 'io.rest-assured:rest-assured'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'	// WebClient 사용
+
+    //OAuth, security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/team01/project/ProjectApplication.java
+++ b/backend/src/main/java/com/team01/project/ProjectApplication.java
@@ -2,7 +2,9 @@ package com.team01.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ProjectApplication {
 

--- a/backend/src/main/java/com/team01/project/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/team01/project/domain/user/controller/UserController.java
@@ -1,0 +1,70 @@
+package com.team01.project.domain.user.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.team01.project.domain.user.repository.RefreshTokenRepository;
+import com.team01.project.global.security.JwtTokenProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@RequestMapping("/user")
+@Controller
+public class UserController {
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@GetMapping("/login")
+	public String loginPage(Authentication authentication) {
+		if (authentication != null && authentication.isAuthenticated()) {
+			System.out.println("인증확인" + authentication);
+			return "redirect:/"; // 이미 인증된 사용자는 메인 페이지로 리다이렉트
+		}
+		return "login"; // 로그인 페이지를 반환
+	}
+
+	@ResponseBody
+	@PostMapping("/logout")
+	public String logout(@RequestBody String userId) {
+		refreshTokenRepository.deleteByUserId(userId);
+		return "로그아웃 성공";
+	}
+
+	@GetMapping("/spotify/logout")
+	public String forceLogout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		System.out.println("강제로그아웃");
+
+		if (authentication != null) {
+			new SecurityContextLogoutHandler().logout(request, response, authentication);
+		}
+		;
+
+		request.getSession().invalidate();
+		return "redirect:https://accounts.spotify.com/en/logout";
+	}
+
+	@ResponseBody
+	@PostMapping("/refresh")
+	public String refreshToken(@RequestBody String refreshToken) {
+		String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+		String newAccessToken = getNewSpotifyAccessToken(refreshToken);
+
+		String newJwtToken = jwtTokenProvider.createToken(userId, newAccessToken);
+		return newJwtToken;
+	}
+
+	private String getNewSpotifyAccessToken(String refreshToken) {
+		return refreshToken;
+	}
+}

--- a/backend/src/main/java/com/team01/project/domain/user/dto/UserDto.java
+++ b/backend/src/main/java/com/team01/project/domain/user/dto/UserDto.java
@@ -1,0 +1,41 @@
+package com.team01.project.domain.user.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.team01.project.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class UserDto {
+	private String id;
+	private String email;
+	private String name;
+	private String nickName;
+	private LocalDate birthDay;
+	private LocalDateTime createdDate;
+	private String field;
+	private long followId;
+
+	//엔티티 -> DTO 변환
+
+	public static UserDto of(User user) {
+		return UserDto.builder()
+			.id(user.getId())
+			.email(user.getEmail())
+			.name(user.getName())
+			.nickName(user.getNickName())
+			.birthDay(user.getBirthDay())
+			.createdDate(user.getCreatedDate())
+			.field(user.getField())
+			.followId(user.getFollowId())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/team01/project/domain/user/entity/RefreshToken.java
+++ b/backend/src/main/java/com/team01/project/domain/user/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package com.team01.project.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(name = "REFRESH_TOKEN")
+public class RefreshToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", referencedColumnName = "USER_ID", nullable = false)
+	private User user;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT")
+	private LocalDateTime createdAt;
+
+	@Column(name = "REFRESH_TOKEN")
+	private String refreshToken;
+}

--- a/backend/src/main/java/com/team01/project/domain/user/entity/User.java
+++ b/backend/src/main/java/com/team01/project/domain/user/entity/User.java
@@ -1,0 +1,58 @@
+package com.team01.project.domain.user.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(name = "USER")
+public class User {
+	@Id
+	@Column(name = "USER_ID")
+	private String id;
+
+	@Email
+	@Column(name = "USER_EMAIL")
+	private String email;
+
+	@Column(name = "NAME")
+	private String name;
+
+	@Column(name = "Nickname")
+	private String nickName;
+
+	@Column(name = "birthday")
+	private LocalDate birthDay;
+
+	@CreatedDate
+	@Column(name = "CREATED_AT")
+	private LocalDateTime createdDate;
+
+	@Column(name = "Field")
+	private String field;
+
+	@Column(name = "follow_id")
+	private long followId;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<RefreshToken> refreshTokens;
+
+}

--- a/backend/src/main/java/com/team01/project/domain/user/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/team01/project/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.team01.project.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.team01.project.domain.user.entity.RefreshToken;
+import com.team01.project.domain.user.entity.User;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	Optional<RefreshToken> findByUserId(String userId);
+
+	void deleteByUserId(String userId);
+
+	String user(User user);
+}

--- a/backend/src/main/java/com/team01/project/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/team01/project/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.team01.project.domain.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.team01.project.domain.user.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+	List<User> findAll();
+}

--- a/backend/src/main/java/com/team01/project/domain/user/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/team01/project/domain/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,89 @@
+package com.team01.project.domain.user.service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.team01.project.domain.user.entity.RefreshToken;
+import com.team01.project.domain.user.entity.User;
+import com.team01.project.domain.user.repository.RefreshTokenRepository;
+import com.team01.project.domain.user.repository.UserRepository;
+import com.team01.project.global.security.JwtTokenProvider;
+
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+	@Autowired
+	private UserRepository userRepository;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+		if (userRequest == null) {
+			throw new RuntimeException("OAuth2UserRequest가 null입니다.");
+		}
+
+		if (userRequest.getAccessToken() == null) {
+			throw new RuntimeException("OAuth2 Access Token이 null입니다.");
+		}
+
+		OAuth2User user = delegate.loadUser(userRequest);
+		String accessToken = userRequest.getAccessToken().getTokenValue();
+		System.out.println("access token:" + accessToken);
+		System.out.println("User Attributes: " + user.getAttributes()); // OAuth 사용자 정보 확인
+
+		//리프레시 토큰 저장 ( DB에 저장 )
+		String userId = user.getName();
+		if (userId == null) {
+			throw new RuntimeException("OAuth2 사용자 ID를 찾을 수 없습니다.");
+		}
+
+		System.out.println("OAuth2 User ID: " + userId);
+		User foundUser = userRepository.findById(userId).orElse(null);
+
+		//db에 사용자 없을 시 생성
+		if (foundUser == null) {
+			foundUser = User.builder()
+				.id(userId)
+				.name(user.getAttribute("display_name"))
+				.email(user.getAttribute("email"))
+				.createdDate(LocalDateTime.now())
+				.build();
+
+			userRepository.save(foundUser);
+			System.out.println("최초 로그인 사용자 저장:" + userId);
+		}
+
+		RefreshToken refreshToken = RefreshToken.builder()
+			.user(foundUser)
+			.refreshToken(accessToken)
+			.createdAt(LocalDateTime.now())
+			.build();
+
+		refreshTokenRepository.save(refreshToken);
+
+		//JWT 발급
+		String jwtToken = jwtTokenProvider.createToken(userId, accessToken);
+
+		return new DefaultOAuth2User(
+			Collections.singleton(new SimpleGrantedAuthority("USER")),
+			user.getAttributes(),
+			"id"
+		);
+	}
+}

--- a/backend/src/main/java/com/team01/project/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/team01/project/domain/user/service/UserService.java
@@ -1,0 +1,13 @@
+package com.team01.project.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.team01.project.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+	private final UserRepository userRepository;
+}

--- a/backend/src/main/java/com/team01/project/global/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/team01/project/global/security/JwtTokenProvider.java
@@ -1,0 +1,66 @@
+package com.team01.project.global.security;
+
+import java.security.Key;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.team01.project.domain.user.entity.User;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+	private static final Key SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+	private static final long VALIDITY_IN_MS = 3600000L; // 1시간\
+	private User user;
+
+	//jwt 토큰 생성
+	public String createToken(String userId, String spotifyAccessToken) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("sub", userId); // subject 설정
+		claims.put("spotifyToken", spotifyAccessToken); //추가 Claims
+
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime validity = now.plus(Duration.ofMillis(VALIDITY_IN_MS));
+
+		Date issuedAt = Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
+		Date expiration = Date.from(validity.atZone(ZoneId.systemDefault()).toInstant());
+
+		return Jwts.builder()
+			.addClaims(claims) // Immutable 오류 방지
+			.setIssuedAt(issuedAt)
+			.setExpiration(expiration)
+			.signWith(SignatureAlgorithm.HS256, SECRET_KEY) // ES256 → HS256으로 변경
+			.compact();
+	}
+
+	//jwt 토큰 검증 및 사용자 정보 추출
+	public String getUserIdFromToken(String token) {
+
+		JwtParser parser = Jwts.parser().setSigningKey(SECRET_KEY).build();
+		Claims claims = parser.parseClaimsJws(token).getBody();
+		return claims.getSubject();
+	}
+
+	//jwt 토큰 유효한 형식인 지 검증
+	public boolean validateToken(String token) {
+		try {
+			JwtParser parser = Jwts.parser().setSigningKey(SECRET_KEY).build();
+			parser.parseClaimsJws(token);
+			return true;
+		} catch (JwtException e) {
+			return false;
+		}
+	}
+}

--- a/backend/src/main/java/com/team01/project/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/team01/project/global/security/SecurityConfig.java
@@ -1,0 +1,40 @@
+package com.team01.project.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher("/**") // 모든 요청에 대해 보안 적용
+			.csrf(csrf -> csrf.disable())
+			.authorizeHttpRequests(authorizeRequests ->
+				authorizeRequests
+					.requestMatchers("/api/v1/user/login", "/api/v1/user/logout", "/api/v1/user/refresh",
+						"/login/oauth2/code/spotify", "/").permitAll()
+					.anyRequest().authenticated()) // 모든 요청에 대해 인증 필요
+			.oauth2Login(oauth2 -> oauth2
+					.userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
+					.defaultSuccessUrl("/api/v1", true) // 로그인 성공 시 리다이렉트 url
+					.failureUrl("/login?error=true")// 로그인 실패 시 리다이렉트 url
+				// .authorizationEndpoint(authorization ->
+				// 	authorization.baseUri("/oauth2/authorization")) // OAuth 인증 경로
+			);
+		return http.build();
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,11 +10,30 @@ spring:
     username: ${USER}
     password: ${PASSWORD}
 
+  security:
+    oauth2:
+      client:
+        registration:
+          spotify:
+            client-id: fadbee879e0e4575a2bb28abfe276934
+            client-secret: 9a938eb715544e279e03a547c0e64aa5
+            scope: user-read-private, user-read-email
+            redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/spotify
+            authorization-grant-type: authorization_code
+            client-name: Spotify
+        provider:
+          spotify:
+            authorization-uri: https://accounts.spotify.com/authorize
+            token-uri: https://accounts.spotify.com/api/token
+            user-info-uri: https://api.spotify.com/v1/me
+            user-name-attribute: id
+
   logging:
     level:
       org:
         hibernate:
           SQL: debug
+      org.springframework.security: DEBUG
 
   jpa:
     database: mysql

--- a/backend/src/test/java/com/team01/project/user/repository/RefreshTokenRepositoryTest.java
+++ b/backend/src/test/java/com/team01/project/user/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.team01.project.user.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.team01.project.domain.user.entity.RefreshToken;
+import com.team01.project.domain.user.entity.User;
+import com.team01.project.domain.user.repository.RefreshTokenRepository;
+import com.team01.project.domain.user.repository.UserRepository;
+
+@SpringBootTest
+public class RefreshTokenRepositoryTest {
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	public void testCreateRefreshToken() {
+		Optional<User> userOptional = userRepository.findById("1234");
+		if (userOptional.isEmpty()) {
+			System.out.println("유저 아이디 중 1234가 없음.");
+			return;
+		}
+
+		User user = userOptional.get();
+
+		if (user != null) {
+			RefreshToken refreshToken = RefreshToken.builder()
+				.user(user)
+				.refreshToken("sampleRefreshToken")
+				.createdAt(LocalDateTime.now())
+				.build();
+
+			RefreshToken saveToken = refreshTokenRepository.save(refreshToken);
+			System.out.println("리프레시 토큰 저장 완료:" + saveToken.getRefreshToken());
+		}
+	}
+}

--- a/backend/src/test/java/com/team01/project/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/team01/project/user/repository/UserRepositoryTest.java
@@ -1,0 +1,40 @@
+package com.team01.project.user.repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.team01.project.domain.user.entity.User;
+import com.team01.project.domain.user.repository.UserRepository;
+
+@SpringBootTest
+public class UserRepositoryTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	public void testCreateUser() {
+
+		LocalDate localDate = LocalDate
+			.parse("2000-01-02", DateTimeFormatter
+				.ofPattern("yyyy-MM-dd"));
+
+		User user = User.builder()
+			.id("asdf1234")
+			.email("test@example.com")
+			.createdDate(LocalDateTime.now())
+			.name("name")
+			.nickName("nickName")
+			.birthDay(localDate)
+			.followId(1L)
+			.field("사용자")
+			.build();
+
+		userRepository.save(user);
+	}
+}

--- a/backend/src/test/java/com/team01/project/user/security/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/team01/project/user/security/JwtTokenProviderTest.java
@@ -1,0 +1,51 @@
+package com.team01.project.user.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.team01.project.global.security.JwtTokenProvider;
+
+@SpringBootTest
+public class JwtTokenProviderTest {
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Test
+	void testCreateToken() {
+		String userId = "asdf1234";
+		String spotifyAccessToken = "spotifyTestToken";
+
+		String token = jwtTokenProvider.createToken(userId, spotifyAccessToken);
+		String extractedUserId = jwtTokenProvider.getUserIdFromToken(token);
+
+		System.out.println("토큰:" + token);
+		System.out.println("토큰에서 추출한 사용자 ID:" + extractedUserId);
+		assertNotNull(token);
+		assertEquals(userId, extractedUserId);
+	}
+
+	@Test
+	void testValidateTokenValid() {
+		String userId = "validUser";
+		String spotifyAccessToken = "spotifyTestToken";
+		String token = jwtTokenProvider.createToken(userId, spotifyAccessToken);
+
+		boolean isValid = jwtTokenProvider.validateToken(token);
+
+		assertTrue(isValid);
+	}
+
+	@Test
+	void testValidateTokenInvaild() {
+
+		String invalidToken = "invalid.token.value";
+
+		boolean isValid = jwtTokenProvider.validateToken(invalidToken);
+
+		assertFalse(isValid);
+	}
+}

--- a/backend/src/test/java/com/team01/project/user/service/CustomOAuth2UserServiceTest.java
+++ b/backend/src/test/java/com/team01/project/user/service/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,84 @@
+package com.team01.project.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.team01.project.domain.user.entity.RefreshToken;
+import com.team01.project.domain.user.entity.User;
+import com.team01.project.domain.user.repository.RefreshTokenRepository;
+import com.team01.project.domain.user.repository.UserRepository;
+import com.team01.project.domain.user.service.CustomOAuth2UserService;
+import com.team01.project.global.security.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomOAuth2UserServiceTest {
+
+	@InjectMocks
+	private CustomOAuth2UserService customOAuth2UserService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private OAuth2UserRequest userRequest;
+
+	@Mock
+	private OAuth2User oauth2User;
+
+	@Mock
+	private OAuth2AccessToken oAuth2AccessToken;
+
+	@BeforeEach
+	void setUp() {
+		when(userRequest.getAccessToken()).thenReturn(oAuth2AccessToken);
+		when(oAuth2AccessToken.getTokenValue()).thenReturn("mockAccessToken");
+	}
+
+	@Test
+	void testLoadUser_success() {
+
+		//테스트 데이터
+		String userId = "asdf1234";
+		String accessToken = "spotifyAccessToken";
+		User mockUser = User.builder()
+			.id(userId)
+			.email("test@example.com")
+			.build();
+
+		// OAuth2User가 반환할 속성 설정
+		Map<String, Object> attributes = Map.of("id", userId);
+		given(oauth2User.getAttributes()).willReturn(attributes);
+		given(oauth2User.getName()).willReturn(userId);
+		given(userRequest.getAccessToken().getTokenValue()).willReturn(accessToken);
+		given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+		given(jwtTokenProvider.createToken(userId, accessToken)).willReturn("mockJwtToken");
+
+		// When (테스트 실행)
+		OAuth2User result = customOAuth2UserService.loadUser(userRequest);
+
+		// Then (검증)
+		assertNotNull(result);
+		assertEquals(userId, result.getName());
+		verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+		verify(jwtTokenProvider, times(1)).createToken(userId, accessToken);
+	}
+}


### PR DESCRIPTION

## 🔎 작업 내용
소셜 인증 없으면 스포티파이 로그인 페이지로 리다이렉트
소셜 인증 후 user 테이블에 user 데이터 적재, refresh_token 테이블에 token 적재

spotify access token 과 사용자 id를 통해 jwt 토큰 발급
토큰 만료 후 토큰 갱신 기능

  <br/>


<br/>

## ➕ 이슈 링크
- [feat#21/shinwoos#21](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team01/issues/21)

<br/>

<!-- closed #번호 -->
