### PR TITLE
feat(38): 캘린더 상세 페이지 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "embla-carousel-react": "^8.5.2",
         "lucide-react": "^0.479.0",
         "next": "^15.1.7",
         "react": "^19.0.0",
@@ -2401,6 +2402,34 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.2.tgz",
+      "integrity": "sha512-xQ9oVLrun/eCG/7ru3R+I5bJ7shsD8fFwLEY7yPe27/+fDHCNj0OT5EoG5ZbFyOxOcG6yTwW8oTz/dWyFnyGpg==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.2.tgz",
+      "integrity": "sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.5.2",
+        "embla-carousel-reactive-utils": "8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.2.tgz",
+      "integrity": "sha512-QC8/hYSK/pEmqEdU1IO5O+XNc/Ptmmq7uCB44vKplgLKhB/l0+yvYx0+Cv0sF6Ena8Srld5vUErZkT+yTahtDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.2"
       }
     },
     "node_modules/emoji-regex": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1452,7 +1452,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2265,7 +2265,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5697,7 +5697,6 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.14.tgz",
       "integrity": "sha512-92YT2dpt671tFiHH/e1ok9D987N9fHD5VWoly1CdPD/Cd1HMglvZwP3nx2yTj2lbXDAHt8QssZkxTLCCTNL+xw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "embla-carousel-react": "^8.5.2",
     "lucide-react": "^0.479.0",
     "next": "^15.1.7",
     "react": "^19.0.0",

--- a/frontend/src/app/calendar/[id]/page.tsx
+++ b/frontend/src/app/calendar/[id]/page.tsx
@@ -81,30 +81,41 @@ export default function MusicDetailPage() {
         </div>
         <Carousel className="w-full max-w-2xl">
             <CarouselContent>
-                {musicRecord?.musics?.map((music) => <CarouselItem key={music.id} className="flex justify-center h-full">
-                    <Card className="w-full h-full border-1 border-gray-300">
-                        <CardContent className="flex flex-col items-center p-4">
-                            <img
-                                src={music.albumImage}
-                                alt={music.name}
-                                className="w-full h-60 object-cover rounded-lg"
-                            />
-                            <h2 className="text-lg font-semibold text-[#393D3F] mt-2">{music.name}</h2>
-                            <p className="text-sm text-gray-500">{music.singer}</p>
-                            <p className="text-sm text-gray-400">{music.genre}</p>
-                            <p className="text-sm text-gray-400">{music.releaseDate.replaceAll("-", ".")}</p>
-                        </CardContent>
-                    </Card>
-                </CarouselItem>)}
+                {musicRecord?.musics?.map((music) => (
+                    <CarouselItem key={music.id} className="flex justify-center h-full">
+                        <Card className="w-full h-full border-1 border-gray-300">
+                            <CardContent className="flex flex-row items-center p-4">
+                                <img
+                                    src={music.albumImage}
+                                    alt={music.name}
+                                    className="w-1/3 h-1/3 object-contain rounded-lg"
+                                />
+
+                                <div className="flex flex-col items-start m-10 space-y-4">
+                                    <div className="space-y-2">
+                                        <h2 className="text-3xl font-semibold text-[#393D3F]">{music.name}</h2>
+                                        <p className="text-lg text-[#393D3F]">{music.singer}</p>
+                                    </div>
+                                    <div className="space-y-2">
+                                        <p className="text-lg text-[#393D3F]">{music.genre}</p>
+                                        <p className="text-lg text-gray-400">
+                                            {music.releaseDate.replaceAll("-", ".")}
+                                        </p>
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </CarouselItem>
+                ))}
             </CarouselContent>
-            <CarouselPrevious />
-            <CarouselNext />
+            <CarouselPrevious/>
+            <CarouselNext/>
         </Carousel>
 
         {/* 메모 영역 */}
         <div className="w-full max-w-2xl mt-6 p-4 rounded-lg shadow">
-            <h3 className="text-md font-medium text-[#393D3F]">메모</h3>
-            <p className="mt-2 text-sm text-[#393D3F]">{musicRecord?.memo}</p>
+            <h3 className="text-md text-gray-400">메모</h3>
+            <p className="mt-2 text-md text-[#393D3F]">{musicRecord?.memo}</p>
         </div>
     </div>;
 }

--- a/frontend/src/app/calendar/[id]/page.tsx
+++ b/frontend/src/app/calendar/[id]/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { Card, CardContent } from "@/components/ui/card";
+import {useEffect, useState} from "react";
+import {useParams, useRouter, useSearchParams} from "next/navigation";
+
+interface Music {
+    id: string;
+    name: string;
+    singer: string;
+    singerId: string;
+    releaseDate: string;
+    albumImage: string;
+    genre: string;
+}
+
+interface MusicRecord {
+    id: number;
+    date: string;
+    memo: string;
+    musics: Music[];
+}
+
+export default function MusicDetailPage() {
+    const [musicRecord, setMusicRecord] = useState<MusicRecord>();
+    const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
+    const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth() + 1);
+    const [currentDay, setCurrentDay] = useState<number>(new Date().getDay());
+    const searchParams = useSearchParams();
+    const [isReadOnly, setIsReadOnly] = useState(false);
+    const params = useParams();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!searchParams.has("readOnly")) {
+            setIsReadOnly(false);
+        } else {
+            const value = searchParams.get("readOnly");
+            setIsReadOnly(value === null || value === "true");
+        }
+    }, [searchParams]);
+
+    useEffect(() => {
+        const fetchMusicRecords = async () => {
+            const res = await fetch(
+                `http://localhost:8080/api/v1/calendar/${params.id}`,
+                {
+                    method: "GET",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    credentials: "include",
+                }
+            );
+
+            const data: MusicRecord = await res.json();
+            const [year, month, day] = data.date.split("-");
+
+            setMusicRecord(data);
+            setCurrentYear(parseInt(year, 10));
+            setCurrentMonth(parseInt(month, 10));
+            setCurrentDay(parseInt(day, 10));
+        };
+
+        fetchMusicRecords();
+    }, []);
+
+    const handleButtonClick = () => {
+        router.push(`/calendar/record?id=${musicRecord!.id}`);
+    }
+
+    return <div className="flex flex-col items-center justify-center w-full max-w-3xl mx-auto mt-3">
+        <div className="w-full max-w-2xl flex justify-between mb-3">
+            <h2 className="text-lg text-[#393D3F]">{currentYear}년 {currentMonth}월 {currentDay}일</h2>
+            {
+                !isReadOnly && <button className="text-lg text-[#393D3F]" onClick={handleButtonClick}>수정하기</button>
+            }
+        </div>
+        <Carousel className="w-full max-w-2xl">
+            <CarouselContent>
+                {musicRecord?.musics?.map((music) => <CarouselItem key={music.id} className="flex justify-center h-full">
+                    <Card className="w-full h-full border-1 border-gray-300">
+                        <CardContent className="flex flex-col items-center p-4">
+                            <img
+                                src={music.albumImage}
+                                alt={music.name}
+                                className="w-full h-60 object-cover rounded-lg"
+                            />
+                            <h2 className="text-lg font-semibold text-[#393D3F] mt-2">{music.name}</h2>
+                            <p className="text-sm text-gray-500">{music.singer}</p>
+                            <p className="text-sm text-gray-400">{music.genre}</p>
+                            <p className="text-sm text-gray-400">{music.releaseDate.replaceAll("-", ".")}</p>
+                        </CardContent>
+                    </Card>
+                </CarouselItem>)}
+            </CarouselContent>
+            <CarouselPrevious />
+            <CarouselNext />
+        </Carousel>
+
+        {/* 메모 영역 */}
+        <div className="w-full max-w-2xl mt-6 p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium text-[#393D3F]">메모</h3>
+            <p className="mt-2 text-sm text-[#393D3F]">{musicRecord?.memo}</p>
+        </div>
+    </div>;
+}

--- a/frontend/src/app/calendar/[id]/page.tsx
+++ b/frontend/src/app/calendar/[id]/page.tsx
@@ -22,6 +22,8 @@ interface MusicRecord {
     musics: Music[];
 }
 
+const BASE_URL = "http://localhost:8080/api/v1";
+
 export default function MusicDetailPage() {
     const [musicRecord, setMusicRecord] = useState<MusicRecord>();
     const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
@@ -44,7 +46,7 @@ export default function MusicDetailPage() {
     useEffect(() => {
         const fetchMusicRecords = async () => {
             const res = await fetch(
-                `http://localhost:8080/api/v1/calendar/${params.id}`,
+                BASE_URL + `/calendar/${params.id}`,
                 {
                     method: "GET",
                     headers: {

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -4,7 +4,7 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import {useEffect, useState} from "react";
-import {DatesSetArg, EventContentArg} from "@fullcalendar/core";
+import {DatesSetArg, EventClickArg, EventContentArg} from "@fullcalendar/core";
 import {useRouter, useSearchParams} from "next/navigation";
 
 interface CalendarDate {
@@ -233,6 +233,18 @@ const Calendar: React.FC = () => {
         }
     });
 
+    const handleEventClick = (arg: EventClickArg) => {
+        if (!arg.event.start) return;
+
+        const date = arg.event.start.toLocaleDateString("ko-KR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+        }).replace(/\./g, "").split(" ").join("-");
+
+        handleDateClick({ dateStr: date });
+    };
+
     return (
         <div className="flex flex-col w-full px-10 justify-center items-center">
             <div className="w-9/12 flex justify-end mt-4 mb-4">
@@ -263,8 +275,10 @@ const Calendar: React.FC = () => {
                     dayCellContent={handleDayCellContent}
                     datesSet={handleDateChange}
                     dateClick={handleDateClick}
+                    eventClick={handleEventClick}
                     dayMaxEvents={true}
                     events={monthly.map((arg) => ({
+                        start: arg.date,
                         date: arg.date,
                         borderColor: "#FFFFFF",
                         backgroundColor: "#FFFFFF",

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -40,7 +40,7 @@ const Calendar: React.FC = () => {
     const [followingCount, setFollowingCount] = useState(0);
     const [followerCount, setFollowerCount] = useState(0);
     const [ownerId, setOwnerId] = useState<string | null>(null);
-    const [isCalendarOwner, setIsCalendarOwner] = useState<boolean>(true);
+    const [isCalendarOwner, setIsCalendarOwner] = useState<boolean>(false);
     const router = useRouter();
     const params = useSearchParams();
 
@@ -226,6 +226,10 @@ const Calendar: React.FC = () => {
             const day = parseInt(dayStr, 10);
 
             router.push(`/calendar/record?year=${year}&month=${month}&day=${day}`);
+        } else if (clickedDate && isCalendarOwner) {
+            router.push(`/calendar/${clickedDate.id}`);
+        } else if (clickedDate && !isCalendarOwner) {
+            router.push(`/calendar/${clickedDate.id}?readOnly=true`);
         }
     });
 

--- a/frontend/src/components/ui/carousel.tsx
+++ b/frontend/src/components/ui/carousel.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins
+  )
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        scrollPrev()
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        scrollNext()
+      }
+    },
+    [scrollPrev, scrollNext]
+  )
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on("reInit", onSelect)
+    api.on("select", onSelect)
+
+    return () => {
+      api?.off("select", onSelect)
+    }
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -left-12 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -right-12 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 먼슬리 캘린더 페이지와 캘린더 상세 페이지 연결
- 음악 기록 조회
- 메모 조회
- 수정 권한 유무에 따른 수정하기 버튼 표시 처리
- 수정하기 버튼 클릭 시 기록 수정 페이지로 라우팅

  <br/>

## 이미지 첨부
<img width="958" alt="image" src="https://github.com/user-attachments/assets/934416e3-81e4-4921-b96e-56103a6b40de" />
<br/>

## ➕ 이슈 링크
#38 

<br/>

<!-- closed #38  -->
