### PR TITLE
refactor(94): 캘린더 API HTTP 메서드 변경

### DIFF
--- a/backend/src/main/java/com/team01/project/domain/calendardate/controller/CalendarDateController.java
+++ b/backend/src/main/java/com/team01/project/domain/calendardate/controller/CalendarDateController.java
@@ -11,6 +11,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -119,13 +120,13 @@ public class CalendarDateController {
 	}
 
 	/**
-	 * 음악 기록 저장
+	 * 음악 기록 수정
 	 * @param calendarDateId 캘린더 아이디
 	 * @param request 음악 아이디 리스트
 	 * @param loggedInUser 현재 인증된 유저
 	 */
-	@Operation(summary = "작성된 음악 기록 수정 api", description = "현재 로그인 하고 있는 유저의 음악 기록 수정할때만 사용")
-	@PostMapping("/{calendar-date-id}/music")
+	@Operation(summary = "음악 기록 수정 api", description = "현재 인증된 유저의 특정 캘린더 날짜에 대한 음악 기록 수정")
+	@PutMapping("/{calendar-date-id}/music")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void saveMusicToCalendarDate(@PathVariable(name = "calendar-date-id") Long calendarDateId,
 		@RequestBody CalendarDateMusicSaveRequest request, @AuthenticationPrincipal OAuth2User loggedInUser) {

--- a/backend/src/main/java/com/team01/project/domain/calendardate/controller/CalendarDateController.java
+++ b/backend/src/main/java/com/team01/project/domain/calendardate/controller/CalendarDateController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -135,13 +136,13 @@ public class CalendarDateController {
 	}
 
 	/**
-	 * 메모 작성
+	 * 메모 기록 수정
 	 * @param calendarDateId 캘린더 아이디
 	 * @param request 새로운 메모
 	 * @param loggedInUser 현재 인증된 유저
 	 */
-	@Operation(summary = "작성된 메모 수정 api", description = "현재 로그인 하고 있는 유저의 메모 작성 수정할때만 사용")
-	@PostMapping("/{calendar-date-id}/memo")
+	@Operation(summary = "메모 기록 수정 api", description = "현재 인증된 유저의 특정 캘린더 날짜에 대한 메모 기록 수정")
+	@PatchMapping("/{calendar-date-id}/memo")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void writeMemoToCalendarDate(@PathVariable(name = "calendar-date-id") Long calendarDateId,
 		@RequestBody CalendarDateMemoSaveRequest request, @AuthenticationPrincipal OAuth2User loggedInUser) {

--- a/frontend/src/app/calendar/record/page.tsx
+++ b/frontend/src/app/calendar/record/page.tsx
@@ -90,7 +90,7 @@ export default function CalendarRecordPage() {
 
       if (isEditing) {
         // 기존 기록 수정
-        await axios.post(
+        await axios.put(
           `${API_URL}/calendar/${id}/music`,
           { musicIds: musicIds },
           {
@@ -101,7 +101,7 @@ export default function CalendarRecordPage() {
           }
         );
 
-        await axios.post(
+        await axios.patch(
           `${API_URL}/calendar/${id}/memo`,
           { memo: finalMemo },
           {


### PR DESCRIPTION
## 🔎 작업 내용
- 음악 기록 수정 API의 HTTP 메서드를 `POST`에서 `PUT`으로 변경했습니다.
- 메모 기록 수정 API의 HTTP 메서드를 `POST`에서 `PATCH`로 변경했습니다.
- 주석 및 Swagger 문서를 업데이트했습니다.
- 해당 API를 호출하는 프론트엔드 코드에 변경 사항을 반영했습니다.
- 별도의 테스트 코드는 작성하지 않았고, 직접 실행 후 정상 동작을 확인했습니다.
  <br/>

## ➕ 이슈 링크
- #94 

<br/>

<!-- closed #94  -->
